### PR TITLE
Fix 2-digit page pagination

### DIFF
--- a/src/solvebio.js
+++ b/src/solvebio.js
@@ -188,7 +188,7 @@ SolveBio.prototype.$http = function(path){
               if(response.links) {
                 if(response.links.next) {
                   response.next = function() {
-                    var nextPage = response.links.next.match(/^.*page=(\d)$/)[1];
+                    var nextPage = response.links.next.match(/^.*page=(\d+)$/)[1];
                     var newData = _.assign(JSON.parse(data) || {}, {page: nextPage});
                     return core.ajax(method, path, newData, args);
                   };
@@ -196,7 +196,7 @@ SolveBio.prototype.$http = function(path){
 
                 if(response.links.prev) {
                   response.prev = function() {
-                    var prevPage = response.links.prev.match(/^.*page=(\d)$/)[1];
+                    var prevPage = response.links.prev.match(/^.*page=(\d+)$/)[1];
                     var newData = _.assign(JSON.parse(data) || {}, {page: prevPage});
                     return core.ajax(method, path, newData, args);
                   };

--- a/tests/init.js
+++ b/tests/init.js
@@ -20,8 +20,8 @@ module.exports = function() {
       JSON.stringify({ //body
         url: request.requestURL,
         links: {
-          next: request.requestURL + 'page=3',
-          prev: request.requestURL + 'page=2'
+          next: request.requestURL + 'page=13',
+          prev: request.requestURL + 'page=11'
         }
       })
     );

--- a/tests/test_pagination.spec.js
+++ b/tests/test_pagination.spec.js
@@ -11,4 +11,25 @@ describe('Test Pagination', function() {
         done();
       });
   });
+
+  it('should request 2-digit next page', function(done) {
+    SolveBio.Dataset().all()
+      .then(function(data) {
+        return data.next();
+      })
+      .then(function(dataNext) {
+        expect(dataNext.url).toEqual('https://api.solvebio.com/v1/datasets?page=13');
+        done();
+      });
+  });
+
+  it('should request 2-digit prev page', function(done) {
+    SolveBio.Dataset().all()
+      .then(function(data) {
+        return data.prev();
+      }).then(function(dataPrev) {
+        expect(dataPrev.url).toEqual('https://api.solvebio.com/v1/datasets?page=11');
+        done();
+      });
+  });
 });


### PR DESCRIPTION
Calling `.next()` or `.prev()` on 2-digit pages was not working. It was just a wrong regex.

Besides the fix, I expanded the pagination tests to also test the calls to `.next()` and `.prev()`.
PS: I've never used `fauxJax` before, so not sure if the way I reset it for each test is the proper way.
